### PR TITLE
remove trigger on "java", instead force trigger on "class" changes

### DIFF
--- a/src/java/org/datanucleus/ide/eclipse/jobs/AutoEnhancer.java
+++ b/src/java/org/datanucleus/ide/eclipse/jobs/AutoEnhancer.java
@@ -119,8 +119,8 @@ public class AutoEnhancer extends IncrementalProjectBuilder
         final String[] fileSuffixes = fileSuffix.split(System.getProperty("path.separator"));
         
         final Set<String> relevantFileSuffixes = Stream.of(fileSuffixes).collect(Collectors.toSet());
-        relevantFileSuffixes.remove("class");
-        relevantFileSuffixes.add("java");
+        relevantFileSuffixes.remove("java");
+        relevantFileSuffixes.add("class");
         
         return resource -> {
             if (resource.getType() == IResource.FILE) {


### PR DESCRIPTION
in reference to #10 

actually makes more sense to trigger on changed "class" files instead of "java" files

(realizing this just as I did some real world testing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datanucleus/datanucleus-eclipse-plugin/12)
<!-- Reviewable:end -->
